### PR TITLE
Atualizando versão do módulo para 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+Todas as mudanças importantes deste projeto serão documentadas neste arquivo.  
+O formato segue as diretrizes de [Versionamento Semântico (SemVer)](https://semver.org/).
+
+---
+
+## [1.1.0] - 2025-01-06
+### Adicionado
+- 🆕 **Nova funcionalidade**: Bloqueio de checkout para clientes que atingem um limite de pedidos com um status específico configurado no admin.
+    - Configuração de **Order Status Filter** para selecionar o status a ser considerado.
+    - Configuração de **Order Count Threshold** para definir o número máximo de pedidos permitidos antes do bloqueio.
+- Melhorias na documentação com a inclusão da nova funcionalidade no README.
+
+### Corrigido
+- 🛠️ Ajustes menores no código para melhorar a legibilidade e seguir os padrões PSR-12.
+- Correção de mensagens de log para refletir corretamente as ações realizadas pelo módulo.
+
+---
+
+## [1.0.0] - 2024-12-01
+### Adicionado
+- 🔒 **Bloqueio de checkout**: Impede que clientes marcados como "bloqueados" avancem para o checkout.
+- 📄 **Configurações no Admin**:
+    - Mensagem personalizada para clientes bloqueados.
+    - Redirecionamento para páginas CMS configuradas pelo admin.
+    - Controle ACL para restringir acesso às configurações do módulo.
+- 🛒 **Atributo personalizado**: Adicionado ao perfil do cliente para gerenciar manualmente o status de bloqueio.
+- 📚 **Documentação inicial**: Instruções detalhadas de instalação e configuração.
+
+---
+
+### Notas
+- Para obter mais informações, consulte o [repositório do GitHub](https://github.com/lucaszit/module-lock-checkout).
+

--- a/Model/AdminConfiguration.php
+++ b/Model/AdminConfiguration.php
@@ -18,10 +18,12 @@ use Magento\Store\Model\ScopeInterface;
  */
 class AdminConfiguration
 {
-    public const string XML_PATH_MODULE_ENABLE = 'lock_checkout/general/enable_module';
-    public const string XML_PATH_AUTO_ASSIGN = 'lock_checkout/general/auto_assign';
-    public const string XML_PATH_LOCK_MESSAGE = 'lock_checkout/general/lock_message';
-    public const string XML_PATH_REDIRECT_CHECKOUT = 'lock_checkout/general/redirect_on_lock';
+    public const XML_PATH_MODULE_ENABLE = 'lock_checkout/general/enable_module';
+    public const XML_PATH_ORDER_COUNT = 'lock_checkout/general/order_count_threshold';
+    public const XML_PATH_ORDER_STATUS_FILTER = 'lock_checkout/general/order_status_filter';
+    public const XML_PATH_AUTO_ASSIGN = 'lock_checkout/general/auto_assign';
+    public const XML_PATH_LOCK_MESSAGE = 'lock_checkout/general/lock_message';
+    public const XML_PATH_REDIRECT_CHECKOUT = 'lock_checkout/general/redirect_on_lock';
 
     /**
      * AdminConfiguration Constructor.
@@ -40,6 +42,26 @@ class AdminConfiguration
     public function getModuleEnable(): string
     {
         return $this->scopeConfig->getValue(self::XML_PATH_MODULE_ENABLE, ScopeInterface::SCOPE_STORE);
+    }
+
+    /**
+     * Return order count value
+     *
+     * @return int
+     */
+    public function getOrderCount(): int
+    {
+        return (int) $this->scopeConfig->getValue(self::XML_PATH_ORDER_COUNT, ScopeInterface::SCOPE_STORE);
+    }
+
+    /**
+     * Return order status to filter on checkout validation
+     *
+     * @return string
+     */
+    public function getOrderStatusFilter(): string
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_ORDER_STATUS_FILTER, ScopeInterface::SCOPE_STORE);
     }
 
     /**

--- a/Plugin/CheckoutValidationPlugin.php
+++ b/Plugin/CheckoutValidationPlugin.php
@@ -14,10 +14,13 @@ use Exception;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Action\Action;
 use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use LucasZit\LockCheckout\Model\AdminConfiguration;
+use Magento\Framework\Exception\State\InputMismatchException;
 use Magento\Framework\Message\ManagerInterface;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollectionFactory;
 
 /**
  * Class CheckoutValidationPlugin to lock customer with lock checkout flag
@@ -31,12 +34,14 @@ class CheckoutValidationPlugin
      * @param CustomerRepositoryInterface $customerRepository
      * @param AdminConfiguration $adminConfiguration
      * @param ManagerInterface $messageManager
+     * @param OrderCollectionFactory $orderCollectionFactory
      */
     public function __construct(
         private readonly CustomerSession $customerSession,
         private readonly CustomerRepositoryInterface $customerRepository,
         private readonly AdminConfiguration $adminConfiguration,
         private readonly ManagerInterface $messageManager,
+        private readonly OrderCollectionFactory $orderCollectionFactory
     ) {}
 
     /**
@@ -45,7 +50,7 @@ class CheckoutValidationPlugin
      * @param Action $subject
      * @return null
      */
-    public function beforeDispatch(Action $subject): null
+    public function beforeDispatch(Action $subject)
     {
         if (!$this->adminConfiguration->getModuleEnable() || !$this->customerSession->isLoggedIn()) {
             return null;
@@ -53,6 +58,8 @@ class CheckoutValidationPlugin
 
         try {
             $customerId = (int)$this->customerSession->getCustomerId();
+
+            $this->checkAndSetLockFlag($customerId);
 
             if ($this->isCustomerLocked($customerId)) {
 
@@ -74,6 +81,44 @@ class CheckoutValidationPlugin
     }
 
     /**
+     * CheckAndSetLockFlag to validate order status and number of orders by customer
+     *
+     * @throws NoSuchEntityException
+     * @throws InputMismatchException
+     * @throws InputException
+     * @throws LocalizedException
+     */
+    private function checkAndSetLockFlag(int $customerId): void
+    {
+        $orderCountThreshold = $this->adminConfiguration->getOrderCount();
+        $orderStatus = $this->adminConfiguration->getOrderStatusFilter();
+
+        $orderCount = $this->getOrderCountByStatus($customerId, $orderStatus);
+
+        if ($orderCount >= $orderCountThreshold) {
+            $customer = $this->customerRepository->getById($customerId);
+            $customer->setCustomAttribute('lock_checkout', true);
+            $this->customerRepository->save($customer);
+        }
+    }
+
+    /**
+     * GetOrderCountByStatus to filter order collection and return size
+     *
+     * @param int $customerId
+     * @param string $status
+     * @return int
+     */
+    private function getOrderCountByStatus(int $customerId, string $status): int
+    {
+        $orderCollection = $this->orderCollectionFactory->create()
+            ->addFieldToFilter('customer_id', $customerId)
+            ->addFieldToFilter('status', $status);
+
+        return $orderCollection->getSize();
+    }
+
+    /**
      * Get Customer custom attribute Lock Checkout value.
      *
      * @param int $customerId
@@ -82,10 +127,11 @@ class CheckoutValidationPlugin
      */
     private function isCustomerLocked(int $customerId): bool
     {
-        return (bool) $this->customerRepository
+        $attribute = $this->customerRepository
             ->getById($customerId)
-            ->getCustomAttribute('lock_checkout')
-            ->getValue();
+            ->getCustomAttribute('lock_checkout');
+
+        return $attribute && $attribute->getValue();
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ O módulo **LucasZit_LockCheckout** foi desenvolvido para ajudar lojistas a lida
 - Impedir que clientes com comportamento suspeito realizem novas compras fraudulentas.
 - Configurar mensagens personalizadas para clientes bloqueados.
 - Redirecionar clientes bloqueados para páginas customizadas criadas com o Page Builder do Magento.
+- Bloquear o avanço para o checkout de clientes que tenham uma quantidade de pedidos definida no admin, com o status também definido no admin.
 
 ## 📋 Funcionalidades Principais
 - 🔒 **Bloqueio de Checkout**: Impede que clientes com comportamento suspeito avancem para o checkout.
 - ⚙️ **Configurações Customizáveis**: Permite configurar redirecionamento e mensagens personalizadas.
 - 🛒 **Atributo Customizado no Cliente**: Gerenciamento fácil de bloqueios diretamente no perfil do cliente.
 - 🧑‍💻 **Controle Admin**: ACL para garantir que apenas usuários autorizados possam configurar bloqueios.
+- 📊 **Bloqueio baseado em pedidos**: Bloqueia clientes que atingem o limite de pedidos com um status específico, configurado no admin.
+- 📚 O módulo tem suporte a tradução pt_BR.
 
 
 ## 💻 Instalação

--- a/Test/Unit/Model/AdminConfigurationTest.php
+++ b/Test/Unit/Model/AdminConfigurationTest.php
@@ -71,6 +71,42 @@ class AdminConfigurationTest extends TestCase
     }
 
     /**
+     * TestGetOrderCount
+     *
+     * @covers ::getOrderCount
+     *
+     * @return void
+     */
+    public function testGetOrderCount(): void
+    {
+        $expectedValue = 1;
+        $this->scopeConfigMock->expects($this->once())
+            ->method('getValue')
+            ->with(AdminConfiguration::XML_PATH_ORDER_COUNT, ScopeInterface::SCOPE_STORE)
+            ->willReturn($expectedValue);
+
+        $this->assertEquals($expectedValue, $this->adminConfiguration->getOrderCount());
+    }
+
+    /**
+     * TestGetOrderStatusFilter
+     *
+     * @covers ::getOrderStatusFilter
+     *
+     * @return void
+     */
+    public function testGetOrderStatusFilter(): void
+    {
+        $expectedValue = 'canceled';
+        $this->scopeConfigMock->expects($this->once())
+            ->method('getValue')
+            ->with(AdminConfiguration::XML_PATH_ORDER_STATUS_FILTER, ScopeInterface::SCOPE_STORE)
+            ->willReturn($expectedValue);
+
+        $this->assertEquals($expectedValue, $this->adminConfiguration->getOrderStatusFilter());
+    }
+
+    /**
      * TestGetAutoAssignLockCheckout
      *
      * @covers ::getAutoAssignLockCheckout

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "lucaszit/module-lock-checkout",
     "description": "Restrict checkout access with configurable redirection and messaging.",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "type": "magento2-module",
     "license": "proprietary",
     "authors": [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,7 +21,23 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Select "Yes" to enable the Lock Checkout functionality.</comment>
                 </field>
-                <field id="auto_assign" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="order_status_filter" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Order Status Filter</label>
+                    <source_model>Magento\Sales\Model\ResourceModel\Order\Status\Collection</source_model>
+                    <comment>Select the status to consider for locking the customer.</comment>
+                    <depends>
+                        <field id="enable_module">1</field>
+                    </depends>
+                </field>
+                <field id="order_count_threshold" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Order Count Threshold</label>
+                    <comment>Set the number of orders with the selected status to lock the customer.</comment>
+                    <validate>validate-digits</validate>
+                    <depends>
+                        <field id="enable_module">1</field>
+                    </depends>
+                </field>
+                <field id="auto_assign" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Auto Assign Lock Checkout</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
@@ -29,15 +45,15 @@
                     </depends>
                     <comment>Automatically assign the Lock Checkout attribute as active for new customers.</comment>
                 </field>
-                <field id="redirect_on_lock" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="redirect_on_lock" translate="label comment" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Redirect on Lock</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="enable_module">1</field>
                     </depends>
-                    <comment>Choose "Yes" to redirect locked customers to a specific CMS page Lock Checkout Message. If "No", they will remain on the home page with an error message.</comment>
+                    <comment>Choose "Yes" to redirect locked customers to lock-checkout-message page. If "No", they will remain on the home page with an error message.</comment>
                 </field>
-                <field id="lock_message" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="lock_message" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Message for Locked Checkout</label>
                     <depends>
                         <field id="enable_module">1</field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,6 +10,8 @@
         <lock_checkout>
             <general>
                 <enable_module>0</enable_module>
+                <order_count_threshold>5</order_count_threshold>
+                <order_status_filter>canceled</order_status_filter>
                 <auto_assign>0</auto_assign>
                 <redirect_on_lock>0</redirect_on_lock>
                 <lock_message>Your account is locked for checkout. Please contact support.</lock_message>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,5 +6,5 @@
   @author Lucas Pereira
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="LucasZit_LockCheckout" setup_version="1.0.0"/>
+    <module name="LucasZit_LockCheckout" setup_version="1.1.0"/>
 </config>

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -8,3 +8,8 @@
 "Message for Locked Checkout","Mensagem para Bloqueio de Checkout"
 "This message will be displayed to customers who are locked from proceeding to checkout.","Esta mensagem será exibida aos clientes que estão bloqueados de prosseguir para o checkout."
 "Lock Checkout Message","Mensagem de Bloquear Checkout"
+"Order Status Filter","Filtro de Status de Pedido"
+"Select the status to consider for locking the customer.","Selecione o status a ser considerado para bloquear o cliente."
+"Order Count Threshold","Limite de Contagem de Pedidos"
+"Set the number of orders with the selected status to lock the customer.","Defina o número de pedidos com o status selecionado para bloquear o cliente."
+


### PR DESCRIPTION
- 🆕 **Nova funcionalidade**: Bloqueio de checkout para clientes que atingem um limite de pedidos com um status específico configurado no admin.
    - Configuração de **Order Status Filter** para selecionar o status a ser considerado.
    - Configuração de **Order Count Threshold** para definir o número máximo de pedidos permitidos antes do bloqueio.
- Melhorias na documentação com a inclusão da nova funcionalidade no README.

### Corrigido
- 🛠️ Ajustes menores no código para melhorar a legibilidade e seguir os padrões PSR-12.
- Correção de mensagens de log para refletir corretamente as ações realizadas pelo módulo.